### PR TITLE
Exp/dependency analysis fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ If the dependency analysis finds issues, it will normally cause the build to fai
 * What went wrong:
 Execution failed for task ':analyzeClassesDependencies'.
 > Dependency analysis found issues.
-  usedUndeclaredArtifacts: 
+  Used undeclared dependency: 
    - ch.qos.logback:logback-core:1.2.3@jar
-  unusedDeclaredArtifacts: 
+  Unused declared dependencies: 
    - com.google.guava:guava:25.1-jre@jar
    - commons-io:commons-io:2.5@jar
    - commons-lang:commons-lang:2.4@jar

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-//==============================================================================
-// This software is developed by Stellar Science Ltd Co and the U.S. Government.
-// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
-// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
-//==============================================================================
 plugins {
   id 'java'
   id 'groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.11.2'
+  compile 'org.apache.maven.shared:maven-dependency-analyzer:1.11.3'
 
   testImplementation("commons-io:commons-io:2.6")
   testImplementation("org.spockframework:spock-core:1.3-groovy-2.4") {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+//==============================================================================
+// This software is developed by Stellar Science Ltd Co and the U.S. Government.
+// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
+// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
+//==============================================================================
 plugins {
   id 'java'
   id 'groovy'
@@ -10,7 +15,7 @@ plugins {
 }
 
 group = 'ca.cutterslade.gradle'
-version = '1.4.3-stellar-SNAPSHOT'
+version = '1.4.3-STELLAR-SNAPSHOT'
 
 repositories {
   jcenter()

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -1,8 +1,3 @@
-//==============================================================================
-// This software is developed by Stellar Science Ltd Co and the U.S. Government.
-// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
-// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
-//==============================================================================
 package ca.cutterslade.gradle.analyze
 
 import org.gradle.api.DefaultTask
@@ -50,25 +45,15 @@ class AnalyzeDependenciesTask extends DefaultTask {
     GradleProjectDependencyAnalysis analysis =
             new ProjectDependencyResolver(project, require, allowedToUse, allowedToDeclare, classesDirs, logDependencyInformationToFiles)
                     .analyzeDependencies(name)
-    StringBuffer buffer = new StringBuffer()
-//    ['usedUndeclared', 'unusedDeclared'].each {section ->
-//      def violations = analysis."$section"
-//      if (violations) {
-//        buffer.append("$section: \n")
-//        violations.sort { it.moduleVersion.id.toString() }.each { DefaultResolvedArtifact it ->
-//          def clas = it.classifier ? ":$it.classifier" : ""
-//          buffer.append(" - $it.moduleVersion.id$clas@$it.extension\n")
-//        }
-//      }
-//    }
+    final StringBuffer buffer = new StringBuffer()
     if (analysis.getUnusedDeclared().size() > 0) {
-      buffer.append("Unused declared dependency (unusedDeclaredArtifacts): \n")
+      buffer.append("Unused declared ${analysis.getUnusedDeclared().size()==1?"dependency":"dependencies"}: \n")
       analysis.getUnusedDeclared().each {
         buffer.append(" - $it")
       }
     }
     if (analysis.getUsedUndeclared().size() > 0) {
-      buffer.append("Used undeclared dependency (usedUndeclaredArtifacts): \n")
+      buffer.append("Used undeclared ${analysis.getUsedUndeclared().size() == 1 ? "dependency":"dependencies"}: \n")
       analysis.getUsedUndeclared().each {
         buffer.append(" - $it")
       }

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesTask.groovy
@@ -47,15 +47,15 @@ class AnalyzeDependenciesTask extends DefaultTask {
                     .analyzeDependencies(name)
     final StringBuffer buffer = new StringBuffer()
     if (analysis.getUnusedDeclared().size() > 0) {
-      buffer.append("Unused declared ${analysis.getUnusedDeclared().size()==1?"dependency":"dependencies"}: \n")
+      buffer.append("Unused declared ${analysis.getUnusedDeclared().size() == 1 ? "dependency" : "dependencies"}: ").append(System.lineSeparator())
       analysis.getUnusedDeclared().each {
-        buffer.append(" - $it")
+        buffer.append(" - $it").append(System.lineSeparator())
       }
     }
     if (analysis.getUsedUndeclared().size() > 0) {
-      buffer.append("Used undeclared ${analysis.getUsedUndeclared().size() == 1 ? "dependency":"dependencies"}: \n")
+      buffer.append("Used undeclared ${analysis.getUsedUndeclared().size() == 1 ? "dependency" : "dependencies"}: ").append(System.lineSeparator())
       analysis.getUsedUndeclared().each {
-        buffer.append(" - $it")
+        buffer.append(" - $it").append(System.lineSeparator())
       }
     }
 
@@ -63,7 +63,7 @@ class AnalyzeDependenciesTask extends DefaultTask {
     outputFile.parentFile.mkdirs()
     outputFile.text = buffer.toString()
     if (buffer) {
-      def message = "Dependency analysis found issues.\n$buffer"
+      def message = "Dependency analysis found issues.${System.lineSeparator()}$buffer"
       if (justWarn) {
         logger.warn message
       } else {

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/GradleProjectDependencyAnalysis.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/GradleProjectDependencyAnalysis.groovy
@@ -1,25 +1,14 @@
-//==============================================================================
-// This software is developed by Stellar Science Ltd Co and the U.S. Government.
-// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
-// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
-//==============================================================================
 package ca.cutterslade.gradle.analyze
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 
 class GradleProjectDependencyAnalysis {
-    final Set<ModuleVersionIdentifier> usedDeclaredDependencies
     final Set<ModuleVersionIdentifier> usedUndeclared
     final Set<ModuleVersionIdentifier> unusedDeclared
 
-    GradleProjectDependencyAnalysis(final Set<ModuleVersionIdentifier> usedDeclaredDependencies, final Set<ModuleVersionIdentifier> usedUndeclared, final Set<ModuleVersionIdentifier> unusedDeclared) {
-        this.usedDeclaredDependencies = usedDeclaredDependencies
+    GradleProjectDependencyAnalysis(final Set<ModuleVersionIdentifier> usedUndeclared, final Set<ModuleVersionIdentifier> unusedDeclared) {
         this.usedUndeclared = usedUndeclared
         this.unusedDeclared = unusedDeclared
-    }
-
-    Set<ModuleVersionIdentifier> getUsedDeclaredDependencies() {
-        return new LinkedHashSet<ModuleVersionIdentifier>(usedDeclaredDependencies)
     }
 
     Set<ModuleVersionIdentifier> getUsedUndeclared() {

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/GradleProjectDependencyAnalysis.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/GradleProjectDependencyAnalysis.groovy
@@ -1,0 +1,32 @@
+//==============================================================================
+// This software is developed by Stellar Science Ltd Co and the U.S. Government.
+// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
+// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
+//==============================================================================
+package ca.cutterslade.gradle.analyze
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+
+class GradleProjectDependencyAnalysis {
+    final Set<ModuleVersionIdentifier> usedDeclaredDependencies
+    final Set<ModuleVersionIdentifier> usedUndeclared
+    final Set<ModuleVersionIdentifier> unusedDeclared
+
+    GradleProjectDependencyAnalysis(final Set<ModuleVersionIdentifier> usedDeclaredDependencies, final Set<ModuleVersionIdentifier> usedUndeclared, final Set<ModuleVersionIdentifier> unusedDeclared) {
+        this.usedDeclaredDependencies = usedDeclaredDependencies
+        this.usedUndeclared = usedUndeclared
+        this.unusedDeclared = unusedDeclared
+    }
+
+    Set<ModuleVersionIdentifier> getUsedDeclaredDependencies() {
+        return new LinkedHashSet<ModuleVersionIdentifier>(usedDeclaredDependencies)
+    }
+
+    Set<ModuleVersionIdentifier> getUsedUndeclared() {
+        return new LinkedHashSet<ModuleVersionIdentifier>(usedUndeclared)
+    }
+
+    Set<ModuleVersionIdentifier> getUnusedDeclared() {
+        return new LinkedHashSet<ModuleVersionIdentifier>(unusedDeclared)
+    }
+}

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/ProjectDependencyResolver.groovy
@@ -178,15 +178,15 @@ class ProjectDependencyResolver {
     int misses = 0
     Set<String> classes = qualifiedClassNameByArtifactIdentifier[resolvedArtifact.id]
     if (null == classes) {
-      logger.debug "qualifiedClassNameByArtifactCache miss for $resolvedArtifact"
+      logger.debug "qualifiedClassNameByArtifactIdentifier miss for $resolvedArtifact"
       misses++
       classes = classAnalyzer.analyze(resolvedArtifact.file.toURI().toURL()).asImmutable()
       qualifiedClassNameByArtifactIdentifier.putIfAbsent(resolvedArtifact.id, classes)
     } else {
-      logger.debug "qualifiedClassNameByArtifactCache hit for $resolvedArtifact"
+      logger.debug "qualifiedClassNameByArtifactIdentifier hit for $resolvedArtifact"
       hits++
     }
-    logger.debug "Built qualifiedClassNameByArtifactCache with $hits hits and $misses misses; cache size is ${qualifiedClassNameByArtifactIdentifier.size()}"
+    logger.debug "Built qualifiedClassNameByArtifactIdentifier with $hits hits and $misses misses; cache size is ${qualifiedClassNameByArtifactIdentifier.size()}"
     return classes
   }
 

--- a/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
+++ b/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
@@ -1,8 +1,3 @@
-//==============================================================================
-// This software is developed by Stellar Science Ltd Co and the U.S. Government.
-// Copyright (C) 2020 Stellar Science; U.S. Government has Unlimited Rights.
-// Warning: May contain EXPORT CONTROLLED, FOUO, ITAR, or sensitive information.
-//==============================================================================
 package ca.cutterslade.gradle.analyze
 
 import org.gradle.testkit.runner.BuildResult
@@ -80,9 +75,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration    | expectedResult
-        "compile"        | "usedUndeclaredArtifacts"
-        "implementation" | "usedUndeclaredArtifacts"
-        "compileOnly"    | "usedUndeclaredArtifacts"
+        "compile"        | "Used undeclared "
+        "implementation" | "Used undeclared "
+        "compileOnly"    | "Used undeclared "
         "runtimeOnly"    | BUILD_FAILURE
     }
 
@@ -104,9 +99,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration    | expectedResult
-        "compile"        | "unusedDeclaredArtifacts"
-        "implementation" | "unusedDeclaredArtifacts"
-        "compileOnly"    | "unusedDeclaredArtifacts"
+        "compile"        | "Unused declared"
+        "implementation" | "Unused declared"
+        "compileOnly"    | "Unused declared"
         "runtimeOnly"    | SUCCESS
     }
 
@@ -179,9 +174,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration        | expectedResult
-        "testCompile"        | "unusedDeclaredArtifacts"
-        "testImplementation" | "unusedDeclaredArtifacts"
-        "testCompileOnly"    | "unusedDeclaredArtifacts"
+        "testCompile"        | "Unused declared"
+        "testImplementation" | "Unused declared"
+        "testCompileOnly"    | "Unused declared"
         "testRuntimeOnly"    | SUCCESS
     }
 
@@ -207,9 +202,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration        | expectedResult
-        "testCompile"        | "usedUndeclaredArtifacts"
-        "testImplementation" | "usedUndeclaredArtifacts"
-        "testCompileOnly"    | "usedUndeclaredArtifacts"
+        "testCompile"        | "Used undeclared "
+        "testImplementation" | "Used undeclared "
+        "testCompileOnly"    | "Used undeclared "
         "testRuntimeOnly"    | TEST_BUILD_FAILURE
     }
 

--- a/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
+++ b/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
@@ -251,7 +251,7 @@ class AnalyzeDependenciesPluginSpec extends Specification {
         GradleRunner.create()
                 .withProjectDir(projectDir.getRoot())
                 .withPluginClasspath()
-                .withArguments("-i", "--stacktrace", "--no-parallel", "build")
+                .withArguments("build")
     }
 
     private static void assertBuildSuccess(BuildResult result) {

--- a/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
+++ b/src/test/groovy/ca.cutterslade.gradle.analyze/AnalyzeDependenciesPluginSpec.groovy
@@ -75,9 +75,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration    | expectedResult
-        "compile"        | "Used undeclared "
-        "implementation" | "Used undeclared "
-        "compileOnly"    | "Used undeclared "
+        "compile"        | "Used undeclared"
+        "implementation" | "Used undeclared"
+        "compileOnly"    | "Used undeclared"
         "runtimeOnly"    | BUILD_FAILURE
     }
 
@@ -202,9 +202,9 @@ class AnalyzeDependenciesPluginSpec extends Specification {
 
         where:
         configuration        | expectedResult
-        "testCompile"        | "Used undeclared "
-        "testImplementation" | "Used undeclared "
-        "testCompileOnly"    | "Used undeclared "
+        "testCompile"        | "Used undeclared"
+        "testImplementation" | "Used undeclared"
+        "testCompileOnly"    | "Used undeclared"
         "testRuntimeOnly"    | TEST_BUILD_FAILURE
     }
 


### PR DESCRIPTION
Updated ProjectDependencyResolver.groovy  to track dependencies by ModuleVersionIdentifier instead of as a single File.

With the new Gradle configurations, implementation and api, the implementation of a project can point to the classes directory when resolved, but then permitUnusedDeclared would point to the Jar artifact when resolved. Gradle project dependencies are also allowed to have multiple artifacts, making it impossible to keep a map of only File.
