### PR TITLE
Remove deprecated "testCompileOnly" configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'ca.cutterslade.gradle'
-version = '1.4.3-STELLAR-SNAPSHOT'
+version = '1.4.4-STELLAR-SNAPSHOT'
 
 repositories {
   jcenter()

--- a/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
+++ b/src/main/groovy/ca/cutterslade/gradle/analyze/AnalyzeDependenciesPlugin.groovy
@@ -49,7 +49,6 @@ class AnalyzeDependenciesPlugin implements Plugin<Project> {
       ) {
         require = [
             project.configurations.testCompile,
-            project.configurations.findByName('testCompileOnly'),
             project.configurations.findByName('testCompileClasspath')
         ]
         allowedToUse = [


### PR DESCRIPTION
Trying to resolve the configuration causes a Gradle error:
```text
FAILURE: Build failed with an exception.
     
     * What went wrong:
     Could not determine the dependencies of task ':coordinator:analyzeTestClassesDependencies'.
     > Resolving dependency configuration 'testCompileOnly' is not allowed as it is defined as 'canBeResolved=false'.
       Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'testCompileOnly' should be resolved.
```